### PR TITLE
Add MAILTRAP_INBOX_ID to support accounts with multiple inboxes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,8 @@ variables, in order of decreasing precedence:
 * `MANDRILL_APIKEY`: Mandrill
 * `POSTMARK_API_TOKEN`: Postmark
 * `MAILGUN_SMTP_LOGIN`: Mailgun
-* `MAILTRAP_API_TOKEN`: Mailtrap (for development)
+* `MAILTRAP_API_TOKEN`: Mailtrap (for development).
+  Also set `MAILTRAP_INBOX_ID` when using an account with multiple inboxes.
 
 If no supported environment variable is found, the configuration is left
 blank.  This enables easy defaulting:

--- a/lib/mta_settings.rb
+++ b/lib/mta_settings.rb
@@ -111,14 +111,19 @@ module MtaSettings
       }]
     elsif env['MAILTRAP_API_TOKEN'].present?
       response = Net::HTTP.get(URI.parse("https://mailtrap.io/api/v1/inboxes.json?api_token=#{env['MAILTRAP_API_TOKEN']}"))
-      first_inbox = JSON.parse(response)[0]
+      inboxes = JSON.parse(response)
+      inbox = inboxes[0]
+      if env['MAILTRAP_INBOX_ID'].present?
+        inbox_id = env['MAILTRAP_INBOX_ID'].to_i
+        inbox = inboxes.find { |inbox| inbox['id'] == inbox_id } || inbox
+      end
       [:smtp, {
-        :address              => first_inbox['domain'],
-        :port                 => first_inbox['smtp_ports'][0],
+        :address              => inbox['domain'],
+        :port                 => inbox['smtp_ports'][0],
         :authentication       => :plain,
-        :user_name            => first_inbox['username'],
-        :password             => first_inbox['password'],
-        :domain               => first_inbox['domain']
+        :user_name            => inbox['username'],
+        :password             => inbox['password'],
+        :domain               => inbox['domain']
       }]
     end
   end


### PR DESCRIPTION
Mailtrap API doesn't seem to return the inboxes in any particular order, so when using an upgraded account with multiple inboxes it currently just directs mail into an effectively random inbox.