### PR TITLE
Adding timeout and changing port for mailtrap

### DIFF
--- a/lib/mta_settings.rb
+++ b/lib/mta_settings.rb
@@ -120,9 +120,7 @@ module MtaSettings
         :user_name            => inbox['username'],
         :password             => inbox['password'],
         :domain               => inbox['domain'],
-        :enable_starttls_auto => true,
-        :open_timeout         => 30,
-        :read_timeout         => 30
+        :enable_starttls_auto => true
       }]
     end
   end


### PR DESCRIPTION
Added a new port as it more recommended for mailtrap and more reliable than port 25 : https://mailtrap.io/blog/smtp-ports-25-465-587-used-for/ Added a timeout as with rails 7 in certain situation mails took more than 5 second to be sent and were getting a timeout error Also added enable_starttls_auto as it  detects if STARTTLS is enabled in your SMTP server and starts to use it: https://guides.rubyonrails.org/action_mailer_basics.html


We tested and it is working fine on our end.